### PR TITLE
Fix compilation with boost-1.65 and newer

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -56,7 +56,7 @@ static bool vfLimited[NET_MAX] = {};
 static CNode* pnodeLocalHost = NULL;
 CAddress addrSeenByPeer(CService("0.0.0.0", 0), nLocalServices);
 uint64_t nLocalHostNonce = 0;
-array<int, THREAD_MAX> vnThreadsRunning;
+boost::array<int, THREAD_MAX> vnThreadsRunning;
 static std::vector<SOCKET> vhListenSocket;
 CAddrMan addrman;
 


### PR DESCRIPTION
This error is shown when compiling with boost-1.65:
```
 net.cpp:59:1: error: reference to ‘array’ is ambiguous
 array<int, THREAD_MAX> vnThreadsRunning;
 ^~~~~
In file included from net.h:9:0,
                 from main.h:10,
                 from db.h:8,
                 from net.cpp:6:
/usr/include/boost/array.hpp:61:11: note: candidates are: template<class T, long unsigned int N> class boost::array
     class array {
           ^~~~~
```